### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ type User struct {
 var users []User
 db = db.Where("id > ?", 0)
 
-pagination.Pagging(&pagination.Param{
+pagination.Paging(&pagination.Param{
     DB:      db,
     Page:    1,
     Limit:   3,


### PR DESCRIPTION
The func in source is `Paging` while it's still `Pagging` in the doc.